### PR TITLE
Allow the option of adding a specific config file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,10 @@ default['librenms']['install']['checksum'] = nil
 # auto_update - enabled by default (numerical boolean)
 default['librenms']['auto_update_enabled'] = 1
 
+# optional additional config file to include in config.php
+default['librenms']['add_config_file']['enabled'] = false
+default['librenms']['add_config_file']['path'] = ''
+
 # cron jobs mgmt
 default['librenms']['config']['poller_threads'] = '8'
 default['librenms']['cron']['discovery_all']['enabled'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -250,14 +250,16 @@ template librenms_phpconfigfile do
   group librenms_group
   mode '0644'
   variables(
-    db_pass:  node['mariadb']['user_librenms']['password'],
-    user:     librenms_username,
-    path:     librenms_homedir,
-    auto_up:  node['librenms']['auto_update_enabled'],
-    xdp:      node['librenms']['autodiscover']['xdp'],
-    ospf:     node['librenms']['autodiscover']['ospf'],
-    bgp:      node['librenms']['autodiscover']['bgp'],
-    snmpscan: node['librenms']['autodiscover']['snmpscan'],
+    db_pass:          node['mariadb']['user_librenms']['password'],
+    user:             librenms_username,
+    path:             librenms_homedir,
+    auto_up:          node['librenms']['auto_update_enabled'],
+    xdp:              node['librenms']['autodiscover']['xdp'],
+    ospf:             node['librenms']['autodiscover']['ospf'],
+    bgp:              node['librenms']['autodiscover']['bgp'],
+    snmpscan:         node['librenms']['autodiscover']['snmpscan'],
+    add_conf_enabled: node['librenms']['add_config_file']['enabled'],
+    add_conf_file:    node['librenms']['add_config_file']['path'],
   )
 end
 

--- a/templates/default/config.php.erb
+++ b/templates/default/config.php.erb
@@ -47,3 +47,9 @@ $config['rrdtool_version'] = '1.5.5';
 
 $config['geoloc']['latlng'] = true;
 $config['geoloc']['engine'] = "google"; //Only one available at present
+
+<% if @add_conf_enabled == true %>
+  if(file_exists( __DIR__ . '<%= @add_conf_file_path %>')) {
+    include "<%= @add_conf_file_path %>"
+}
+<% end $>


### PR DESCRIPTION
 - As the main config.php is templated, options not handled by any attributes
   can be added in a second file in attribute.