### PR TITLE
Fix the variable name to enable rrdcached in config.php

### DIFF
--- a/templates/default/config.php.erb
+++ b/templates/default/config.php.erb
@@ -26,7 +26,7 @@ $config['rrd_dir']        = "<%= @rrddir %>";
 ### It will prevent the web interface being usable form any other hostname
 #$config['base_url']        = "http://";
 
-<% if @rrdcached_enabled == true %>
+<% if @rrdc_enabled == true %>
   $config['rrdcached']    = "unix:/var/run/rrdcached/rrdcached.sock";
 <% end %>
 


### PR DESCRIPTION
The variable declared in recipes/default.rb and the templates/default/config.php.erb did not have the same name.