### PR TITLE
Use of ark cookbook for installation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,7 +39,6 @@ default['yum']['epel']['enabled'] = true
 default['librenms']['install']['url'] = 'https://github.com/librenms/librenms/archive/'
 default['librenms']['install']['version'] = '1.35'
 default['librenms']['install']['checksum'] = '72019d9b58b145b617b1e9bfe7f39bd01c9fe5c254e561ef0c80b0a3eb56ac3f'
-default['librenms']['install']['tmpdir'] = '/var/tmp/'
 # override this with the proper archive checksum if you install a
 # specific version and care about checksums.
 default['librenms']['install']['checksum'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,4 +13,5 @@ issues_url 'https://github.com/criteo-cookbooks/librenms/issues' if respond_to?(
 depends	'apache2'
 depends	'logrotate'
 depends 'yum-epel'
+depends 'ark'
 chef_version '>= 12.5' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,6 @@
 include_recipe 'apache2'
 include_recipe 'logrotate'
 
-tmpdir = node['librenms']['install']['tmpdir']
 librenms_rootdir = node['librenms']['root_dir']
 librenms_homedir = ::File.join(node['librenms']['root_dir'], 'librenms')
 librenms_logdir = ::File.join(librenms_homedir, 'logs')
@@ -16,7 +15,6 @@ librenms_username = node['librenms']['user']
 librenms_group = node['librenms']['group']
 librenms_version = node['librenms']['install']['version']
 librenms_file = "#{librenms_version}.zip"
-librenms_archive = ::File.join(tmpdir, librenms_version)
 librenms_phpconfigfile = ::File.join(librenms_homedir, 'config.php')
 
 case node['platform_family']
@@ -183,28 +181,16 @@ user librenms_username do
   manage_home false
 end
 
-remote_file "#{librenms_archive}.zip" do
-  source "#{node['librenms']['install']['url']}/#{librenms_file}"
+ark 'librenms' do
+  url "#{node['librenms']['install']['url']}/#{librenms_file}"
+  path librenms_rootdir
+  home_dir librenms_homedir
+  mode '0755'
+  checksum node['librenms']['install']['checksum'] unless node['librenms']['install']['checksum'].nil?
+  version librenms_version
   owner librenms_username
   group librenms_group
-  mode '0755'
-  not_if { ::File.exist? librenms_archive }
-  checksum node['librenms']['install']['checksum'] unless node['librenms']['install']['checksum'].nil?
-end
-
-execute 'extract librenms archive' do
-  command "/usr/bin/unzip -o #{librenms_archive} -d #{librenms_rootdir}"
-  user 'root'
-  group 'root'
-  umask '022'
-  not_if { ::File.exist? File.join(librenms_homedir, 'README.md') }
-end
-
-execute 'create symlink' do
-  command "ln -s #{node['librenms']['root_dir']}/librenms-#{librenms_version} #{librenms_homedir}"
-  user 'root'
-  group 'root'
-  not_if { ::File.exist? librenms_homedir }
+  action :install
 end
 
 execute 'find and chown' do


### PR DESCRIPTION
 - instead of multiple execute blocks, use ark.
 - solves the symlink bug for upgrade and version changes.