### PR TITLE
Fixed RHEL from not having correct max_connections

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -114,7 +114,10 @@ when 'rhel'
     owner 'root'
     group 'root'
     mode '0644'
-    variables(bind_address: node['mariadb']['bind_address'])
+    variables(
+      bind_address: node['mariadb']['bind_address'],
+      max_connections: node['mariadb']['max_connections'],
+    )
     notifies :restart, 'service[mariadb]'
   end
 


### PR DESCRIPTION
This fixes the fact that the RHEL section that sets up the librenms-mysqld.cnf doesn't include the max_connections variable.